### PR TITLE
Add the accelerometer support.

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
     <queries>
         <package android:name="com.facebook.katana" />
     </queries>

--- a/lib/util/wish_me_luck_service.dart
+++ b/lib/util/wish_me_luck_service.dart
@@ -10,8 +10,7 @@ class WishMeLuckService {
 
 
   //Lista para poblar la base de datos
-  List<Map<String, dynamic>> studentEvents = [
-  ];
+  List<Map<String, dynamic>> studentEvents = [];
 
   Future<WishMeLuckEvent> getWishMeLuckEvent() async {
     try {

--- a/lib/widgets/MagicBall/events_magic_ball.dart
+++ b/lib/widgets/MagicBall/events_magic_ball.dart
@@ -9,7 +9,7 @@ class EmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(40),
+      padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(25),
@@ -25,6 +25,11 @@ class EmptyState extends StatelessWidget {
       child: Column(
         children: [
           const SizedBox(height: 10),
+          Icon(
+            Icons.vibration,
+            color: Color(0xFF6389E2),
+            size: 20,
+          ),
           Text(
             'Shake or Tap the button below',
             style: TextStyle(

--- a/lib/widgets/MagicBall/header_section.dart
+++ b/lib/widgets/MagicBall/header_section.dart
@@ -31,22 +31,15 @@ class HeaderSectionWML extends StatelessWidget {
           children: [
             const SizedBox(height: 8),
 
-            if (lastWished != null) ...[
+            if (lastWished != 0) ...[
               Text(
-                "Last time you wished luck for:",
+                "Last time you wished luck for:$lastWished days ago",
                 style: TextStyle(
                   fontSize: 16,
                   color: Colors.grey[700],
                 ),
               ),
-              Text(
-                "$lastWished days ago",
-                style: TextStyle(
-                  fontSize: 16,
-                  color: Colors.black,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              
             ],
             
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -504,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -624,6 +632,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  sensors_plus:
+    dependency: "direct main"
+    description:
+      name: sensors_plus
+      sha256: "8e7fa79b4940442bb595bfc0ee9da4af5a22a0fe6ebacc74998245ee9496a82d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
+  sensors_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: sensors_plus_platform_interface
+      sha256: bc472d6cfd622acb4f020e726433ee31788b038056691ba433fec80e448a094f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   shared_preferences: ^2.2.2
   flutter_web_auth_2: ^4.1.0
   image_picker: ^0.8.7+6
+  sensors_plus: ^4.0.2
 
 dev_dependencies:
   change_app_package_name: ^1.1.0


### PR DESCRIPTION
This PR implements accelerometer support in the Wish Me Luck feature by integrating the sensors_plus package. Users now have two ways to trigger the "Wish Me Luck" action:

* By pressing the button on the screen.
* By shaking the device, detected through the accelerometer.

**Changes**
* Added accelerometer subscription using sensors_plus.
* Implemented shake detection logic with configurable threshold and cooldown.
* Integrated shake action to trigger the existing wishMeLuck functionality.
* Maintained button option as an alternative trigger for accessibility.

**Why**

This improvement provides a more engaging and interactive user experience, making the feature feel dynamic and fun while still ensuring accessibility through the button.

**Testing**
* Shaking the device triggers "Wish Me Luck" if above the sensitivity threshold.
* Button press still works as expected.
* Cooldown prevents repeated activations from continuous movement.