### PR TITLE
context aware Free-time events 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:app_flutter/firebase_options.dart';
+import 'package:app_flutter/pages/FreeTime/view/free_time_view.dart';
 import 'package:app_flutter/pages/events/view/event_list_view.dart';
 import 'package:app_flutter/pages/login/viewmodels/auth_viewmodel.dart';
 import 'package:app_flutter/pages/login/viewmodels/register_viewmodel.dart';

--- a/lib/pages/FreeTime/model/event.dart
+++ b/lib/pages/FreeTime/model/event.dart
@@ -1,0 +1,76 @@
+import 'package:intl/intl.dart';
+
+class Event {
+  final String id;
+  final String name;
+  final String description;
+  final String category;
+  final String location;
+  final String day;
+  final DateTime startTime;
+  final DateTime endTime;
+  final int durationMinutes;
+  final String organizer;
+  final String imageUrl;
+
+  Event({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.category,
+    required this.location,
+    required this.day,
+    required this.startTime,
+    required this.endTime,
+    required this.durationMinutes,
+    required this.organizer,
+    required this.imageUrl,
+  });
+
+  /// Parsea la hora tanto en formato "10:30 AM" como "17:10"
+  static DateTime parseTime(String timeStr) {
+    try {
+      final formatAmPm = DateFormat('h:mm a');
+      final dt = formatAmPm.parse(timeStr);
+      return DateTime(2025, 1, 1, dt.hour, dt.minute);
+    } catch (_) {
+      final format24 = DateFormat('H:mm');
+      final dt = format24.parse(timeStr);
+      return DateTime(2025, 1, 1, dt.hour, dt.minute);
+    }
+  }
+
+  factory Event.fromMap(Map<String, dynamic> data) {
+    final schedule = data['schedule'] as Map<String, dynamic>;
+    final days = (schedule['days'] as List<dynamic>? ?? []);
+    final times = (schedule['times'] as List<dynamic>? ?? []);
+
+    final startStr = times.isNotEmpty ? times[0] as String : "00:00";
+    final duration = (data['metadata']?['duration_minutes'] as num?)?.toInt() ?? 0;
+
+    final startTime = parseTime(startStr);
+    final endTime = startTime.add(Duration(minutes: duration));
+
+    return Event(
+      id: data['id'] ?? '',
+      name: data['name'] ?? 'Untitled',
+      description: data['description'] ?? '',
+      category: data['category'] ?? 'General',
+      location: data['location']?['address'] ?? 'Unknown',
+      day: days.isNotEmpty ? days[0] as String : '',
+      startTime: startTime,
+      endTime: endTime,
+      durationMinutes: duration,
+      organizer: data['organizer'] ?? '',
+      imageUrl: data['metadata']?['image_url'] ?? '',
+    );
+  }
+
+  @override
+  String toString() {
+    final timeFormat = DateFormat('h:mm a');
+    return 'Event: $name ($category), $day, '
+        '${timeFormat.format(startTime)} - ${timeFormat.format(endTime)} '
+        '@ $location';
+  }
+}

--- a/lib/pages/FreeTime/model/free_time_slot.dart
+++ b/lib/pages/FreeTime/model/free_time_slot.dart
@@ -1,0 +1,31 @@
+import 'package:intl/intl.dart';
+
+class FreeTimeSlot {
+  final String day;
+  final DateTime startTime;
+  final DateTime endTime;
+
+  FreeTimeSlot({
+    required this.day,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  // Función helper para parsear hora con AM/PM a DateTime
+  static DateTime parseTime(String timeStr) {
+    final format = DateFormat('h:mm a'); // "8:00 AM" / "8:00 PM"
+    final dt = format.parse(timeStr);
+    return DateTime(2025, 1, 1, dt.hour, dt.minute); // día fijo
+  }
+
+  factory FreeTimeSlot.fromMap(Map<String, dynamic> data) {
+    return FreeTimeSlot(
+      day: data['day'] as String,
+      startTime: parseTime(data['start'] as String),
+      endTime: parseTime(data['end'] as String),
+    );
+  }
+}
+
+
+

--- a/lib/pages/FreeTime/view/free_time_view.dart
+++ b/lib/pages/FreeTime/view/free_time_view.dart
@@ -1,0 +1,288 @@
+import 'package:app_flutter/pages/FreeTime/model/event.dart';
+import 'package:app_flutter/pages/FreeTime/viewmodel/free_time_viewmodel.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:app_flutter/pages/detailEvent.dart';
+import 'package:app_flutter/pages/notification.dart';
+import 'package:intl/intl.dart';
+import 'package:app_flutter/pages/events/model/event.dart' as EventsModel;
+
+
+
+class FreeTimeView extends StatelessWidget {
+  final String userId;
+
+  const FreeTimeView({super.key, required this.userId});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => FreeTimeViewModel()..loadAvailableEvents(userId),
+      child: const FreeTimeEventsListContent(),
+    );
+  }
+}
+
+class FreeTimeEventsListContent extends StatelessWidget {
+  const FreeTimeEventsListContent({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.watch<FreeTimeViewModel>();
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFFDFBF7),
+      appBar: AppBar(
+        title: const Text(
+          "Available Events",
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            fontSize: 22,
+            color: Colors.white,
+          ),
+        ),
+        backgroundColor: const Color(0xFF6389E2),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.notifications_none, color: Colors.white),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const NotificationsPage(),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Builder(
+        builder: (_) {
+          if (viewModel.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (viewModel.error != null) {
+            return Center(child: Text(viewModel.error!));
+          }
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              // --- FREE TIME SLOTS ---
+              const Text(
+                "Your Free Time",
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              ...viewModel.freeTimeSlots.map((slot) {
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8.0),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.calendar_today, size: 18, color: Colors.orange),
+                      const SizedBox(width: 8),
+                      Text(
+                        slot.day,
+                        style: const TextStyle(fontSize: 16),
+                      ),
+                      const Spacer(),
+                      const Icon(Icons.access_time, size: 16, color: Colors.blue),
+                      const SizedBox(width: 4),
+                      Text(
+                        "${DateFormat.Hm().format(slot.startTime)
+                        } - ${DateFormat.Hm().format(slot.endTime)
+                        }",
+                        style: const TextStyle(color: Colors.black54),
+                      ),
+                    ],
+                  ),
+                );
+              }).toList(),
+
+              const SizedBox(height: 20),
+
+              // --- HEADER DE EVENTS ---
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    "Events That Fit Your Schedule",
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    "${viewModel.availableEvents.length}",
+                    style: const TextStyle(
+                      fontSize: 16,
+                      color: Colors.red,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+
+              // --- LISTA DE EVENTOS ---
+              if (viewModel.availableEvents.isEmpty)
+                const Padding(
+                  padding: EdgeInsets.only(top: 20.0),
+                  child: Center(
+                    child: Text(
+                      "There are no available events during your free time slots",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(fontSize: 16),
+                    ),
+                  ),
+                )
+              else
+                ...viewModel.availableEvents.map(
+                      (event) => EventCard(event: event),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class EventCard extends StatelessWidget {
+  final Event event;
+
+  const EventCard({Key? key, required this.event}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () async {
+        final viewModel = context.read<FreeTimeViewModel>();
+
+        // Mostrar diálogo de carga
+        showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (_) => const Center(child: CircularProgressIndicator()),
+        );
+
+        final fetchedEvent = await viewModel.getEventById(event.id);
+
+        // Cerrar diálogo de carga
+        Navigator.of(context).pop();
+
+        if (fetchedEvent != null) {
+          // IMPORTANTE: DetailEvent debe aceptar el tipo EventsModel.Event
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => DetailEvent(),
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text("Event not found")),
+          );
+        }
+      },
+
+
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 16),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        elevation: 4,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Imagen superior
+            ClipRRect(
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+              child: Image.network(
+                event.imageUrl,
+                height: 180,
+                width: double.infinity,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Image.asset(
+                    "assets/images/event.jpg",
+                    height: 180,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                  );
+                },
+              ),
+            ),
+            // Información del evento
+            Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    event.name,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    event.description,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      const Icon(Icons.location_on_outlined,
+                          size: 16, color: Colors.grey),
+                      const SizedBox(width: 4),
+                      Expanded(
+                        child: Text(
+                          event.location,
+                          style: const TextStyle(color: Colors.grey),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      const Icon(Icons.access_time,
+                          size: 16, color: Colors.grey),
+                      const SizedBox(width: 4),
+                      Text(
+                        "${event.startTime.hour}:${event.startTime.minute.toString().padLeft(2, '0')} - "
+                            "${event.endTime.hour}:${event.endTime.minute.toString().padLeft(2, '0')}",
+                        style: const TextStyle(color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      const Icon(Icons.category,
+                          size: 16, color: Colors.grey),
+                      const SizedBox(width: 4),
+                      Text(
+                        event.category,
+                        style: const TextStyle(color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/FreeTime/viewmodel/free_time_viewmodel.dart
+++ b/lib/pages/FreeTime/viewmodel/free_time_viewmodel.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../../util/firebase_service.dart';
+import '../model/event.dart';
+import '../model/free_time_slot.dart';
+import 'package:app_flutter/pages/events/model/event.dart' as EventsModel;
+
+class FreeTimeViewModel extends ChangeNotifier {
+  final FirebaseFirestore _firestore = FirebaseService.firestore;
+
+  List<Event> _availableEvents = [];
+  List<Event> get availableEvents => _availableEvents;
+
+  List<FreeTimeSlot> _freeTimeSlots = [];
+
+  List<FreeTimeSlot> get freeTimeSlots => _freeTimeSlots;
+
+
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  String? _error;
+  String? get error => _error;
+
+
+
+  Future<void> loadAvailableEvents(String userId) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      // 1️⃣ Cargar los datos del usuario
+      final userDoc = await _firestore.collection('users').doc(userId).get();
+      debugPrint("Loading free time for userId: $userId");
+      if (!userDoc.exists || userDoc.data() == null) {
+        _error = "User not found";
+        _isLoading = false;
+        notifyListeners();
+        return;
+      }
+
+      final userData = userDoc.data()!;
+      final freeSlotsData = ((userData['preferences']?['notifications']?['free_time_slots']) as List<dynamic>?) ?? [];
+
+
+
+      // Mapear free time slots
+      _freeTimeSlots = freeSlotsData.map((slot) {
+        final fts = FreeTimeSlot.fromMap(slot as Map<String, dynamic>);
+        debugPrint("FreeSlot: ${fts.day}, "
+            "${fts.startTime.hour}:${fts.startTime.minute.toString().padLeft(2,'0')} - "
+            "${fts.endTime.hour}:${fts.endTime.minute.toString().padLeft(2,'0')}");
+        return fts;
+      }).toList();
+
+
+
+
+
+      // 2️⃣ Cargar todos los eventos activos
+      final eventsSnapshot =
+      await _firestore.collection('events').where('active', isEqualTo: true).get();
+
+      final events = eventsSnapshot.docs.map((doc) {
+        final Map<String, dynamic> data = doc.data();
+        data['id'] = doc.id;
+        final ev = Event.fromMap(data);
+        debugPrint("Event: ${ev.id}, ${ev.day}, ${ev.startTime} - ${ev.endTime}");
+        return ev;
+      }).toList();
+
+      // 3️⃣ Filtrar eventos según free slots
+      _availableEvents = events.where((event) {
+        final match = _freeTimeSlots.any((slot) {
+          return slot.day.toLowerCase() == event.day.toLowerCase() &&
+              (slot.startTime.isBefore(event.startTime) ||
+                  slot.startTime.isAtSameMomentAs(event.startTime)) &&
+              (slot.endTime.isAfter(event.endTime) ||
+                  slot.endTime.isAtSameMomentAs(event.endTime));
+        });
+
+        if (match) {
+          debugPrint("Matched Event: ${event.name} on ${event.day}");
+        }
+
+        return match;
+      }).toList();
+
+
+      debugPrint("Total available events: ${_availableEvents.length}");
+    } catch (e) {
+      _error = "Error loading data: $e";
+      debugPrint("Error in FreeTimeViewModel: $e");
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<EventsModel.Event?> getEventById(String eventId) async {
+    try {
+      final doc = await _firestore.collection('events').doc(eventId).get();
+
+      if (!doc.exists || doc.data() == null) {
+        return null;
+      }
+
+      // doc.data() es Map<String, dynamic>
+      final Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+
+      // Llamamos al factory correcto (en tu modelo grande es fromJson)
+      return EventsModel.Event.fromJson(doc.id, data);
+    } catch (e) {
+      debugPrint("Error fetching event by id: $e");
+      return null;
+    }
+  }
+
+
+}

--- a/lib/pages/home/home.dart
+++ b/lib/pages/home/home.dart
@@ -10,6 +10,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:app_flutter/pages/profile/viewmodels/profile_viewmodel.dart';
 
+import '../FreeTime/view/free_time_view.dart';
+
 class Home extends StatelessWidget {
   const Home({super.key});
 
@@ -67,8 +69,18 @@ class Home extends StatelessWidget {
                             switch (cardType) {
                               case CardType.weeklyChallenge:
                                 break;
-                              case CardType.personalityQuiz:
+                              case CardType.FreeTimeEvents:
+                                final user = FirebaseAuth.instance.currentUser;
+                                if (user != null) {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => FreeTimeView(userId: user.uid),
+                                    ),
+                                  );
+                                }
                                 break;
+
                               case CardType.wishMeLuck:
                                 mainPageState?.selectTab(2);
                                 break;

--- a/lib/widgets/home_sections_card.dart
+++ b/lib/widgets/home_sections_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-enum CardType { weeklyChallenge, personalityQuiz, wishMeLuck, map }
+enum CardType { weeklyChallenge, FreeTimeEvents, wishMeLuck, map }
 
 class HomeSectionsCard extends StatelessWidget {
   final Function(CardType) onCardTap;
@@ -71,9 +71,9 @@ class _MindCardsGrid extends StatelessWidget {
           onTap: () => onCardTap(CardType.weeklyChallenge),
         ),
         MindCard(
-          title: 'Personality Quiz',
+          title: 'Free Time Events',
           color: Color(0xFFED6275),
-          onTap: () => onCardTap(CardType.personalityQuiz),
+          onTap: () => onCardTap(CardType.FreeTimeEvents),
         ),
         MindCard(
           title: 'Wish me Luck',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -552,6 +552,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.18.1"
   js:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   firebase_storage: ^13.0.2
   google_maps_flutter: ^2.5.0
   image_picker: ^0.8.7+6
+  intl: ^0.18.0
 
 dev_dependencies:
   change_app_package_name: ^1.1.0


### PR DESCRIPTION
This PR implements a context-aware free-time events feature that surfaces events the user can do according to the free-time slots they register during onboarding.

Changes

Free-Time Slot Registration

- Added a registration flow where users declare their typical free-time slots (e.g., weekdays 18:00–20:00, weekends 10:00–14:00).
- Persisted user free-time slots in the profile and exposed them via the user preferences API.

Context-Aware Recommendations
-  Introduced a recommendation engine that matches events to the user’s registered free-time slots.

UI / UX

- Added a “Recommended for your free time” section on the home screen showing events that match the user’s time slots.

Technical Details

- Free-time slots stored as timezone-aware intervals in the user profile.
- Matching logic computes intersection between event time windows and user availability, then ranks by overlap percentage and travel feasibility.
